### PR TITLE
Mark POST data as application/json.

### DIFF
--- a/diditland.js
+++ b/diditland.js
@@ -48,6 +48,9 @@ function requestURL(method, url, responseType, postData) {
   return new Promise(function(resolve, reject) {
     var xhr = new XMLHttpRequest();
     xhr.open(method.toUpperCase(), url);
+    if (method.toUpperCase() == 'POST') {
+      xhr.setRequestHeader("Content-Type", "application/json");
+    }
     if (responseType == "json") {
       xhr.setRequestHeader("Accept", "application/json");
     } else if (responseType == "html") {


### PR DESCRIPTION
Lookup of build ids has been broken for a few weeks. Setting the mimetype on POST requests resolves the issue.

The taskcluster index API requires that POST data come in
as application/json, so set this for all POST method calls,
even when we have no actual data.

The API docs also say the initial request should contain
an empty json object, but appears to accept no data at all.
